### PR TITLE
KB-3997: Fix a PHP warning  on Moodle plugin during the installation

### DIFF
--- a/integration/lib/php/Boot.class.php
+++ b/integration/lib/php/Boot.class.php
@@ -218,7 +218,7 @@ function _hx_char_at($o, $i) { $c = substr($o, $i, 1); return FALSE === $c ? '' 
 
 function _hx_char_code_at($s, $pos) {
 	if($pos < 0 || $pos >= strlen($s)) return null;
-	return ord($s{$pos});
+	return ord($s[$pos]);
 }
 
 function _hx_deref($o) { return $o; }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020070400;
+$plugin->version = 2020080400;
 $plugin->release = '7.21.1';
 $plugin->requires = 2011120511;
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version = 2020070400;
-$plugin->release = '7.21.0';
+$plugin->release = '7.21.1';
 $plugin->requires = 2011120511;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'filter_wiris';


### PR DESCRIPTION
On the Moodle plugin install procedure, this error message appears to the user:

`Deprecated: Array and string offset access syntax with curly braces is deprecated in /var/www/html/minh.edu.vn/filter/wiris/integration/lib/php/Boot.class.php on line 221`

**Expected behaviour:**

The PHP warning message should not appear to the user.

