### PR TITLE
KB-3999: Upgrade MathType filter plugin version to match MathType for Atto/TinyMCE version

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020080400;
+$plugin->version = 2020080600;
 $plugin->release = '7.21.2';
 $plugin->requires = 2011120511;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
The MathType moodle filter plugin and MathType for Atto versions don't match:

This can be checked on this moodle test:

- https://<moodle-address>/filter/wiris/info.php

**Solution**

There are no known incompatibililties between both plugins; everything works fine.
So it's only a matter of updating the version numbers to make them match.

A patch version upgrade is needed on the the affected repositories:

- atto_wiris
- tinymce_tiny_mce_wiris
- filter_wiris (this repo)


Close KB-3999