### PR TITLE
Release 7.26.1 (18th june 2021)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Last release of this plugin is 7.26.0.
+Last release of this plugin is 7.26.1.
 
-## [Unreleased]
+## v7.26.1
 - Feature: 'Migrate MathType plugins suite from TravisCI to Github Actions'.
 
 ## v7.26.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![MathType](./pix/logo-mathtype.png)  MathType Moodle filter plugin by WIRIS
 
-[![Build Status](https://travis-ci.com/wiris/moodle-filter_wiris.svg?branch=stable)](https://travis-ci.com/wiris/moodle-filter_wiris)
+[![Moodle Plugin CI](https://github.com/wiris/moodle-filter_wiris/actions/workflows/moodle-ci.yml/badge.svg)](https://github.com/wiris/moodle-filter_wiris/actions/workflows/moodle-ci.yml)
 
 [MathType](http://www.wiris.com/editor) filter allows Moodle to render MathML using MathType image service. This plugin is part of set [WIRIS math & science](https://moodle.org/plugins/browse.php?list=set&id=66).
 

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021050600;
-$plugin->release = '7.26.0';
+$plugin->version = 2021061800;
+$plugin->release = '7.26.1';
 $plugin->requires = 2011120511;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'filter_wiris';


### PR DESCRIPTION
### Changelog:

- Feature: 'Migrate MathType plugins suite from TravisCI to Github
  Actions'.

#### Migrate test build machine from TravisCI to Github

- Add workflow based on 'moodle-plugin-ci'.
- Exclude phpunit test execution on Moodle3_10+.
- Remove TravisCI script from the project.
- Update .gitignore with custom paths.
- Update CHANGELOG
  See: https://github.com/moodlehq/moodle-plugin-ci
- Fix lint issues on privacy class.
- Add full matrix to the tests
- Lint code on tests.
- Add Moodle .env variables.