### PR TITLE
CI/CD Pipeline is broken: fix code checker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this plugin is 7.27.1 (9th of nov. 2021).
 
+## [Unreleased]
+- fix(ci): moodle code checker warning and errors #19424.
+
 ## v7.27.1 - 9th nov. 2021
 - Fix "missing ['privacy:metadata']" from @christina-roperto contribution #86
 - Improve the "MathType Moodle Plugins Suite" software development cycle.

--- a/classes/moodledbcache.php
+++ b/classes/moodledbcache.php
@@ -23,9 +23,6 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-defined('MOODLE_INTERNAL') || die();
-
 class moodledbcache {
 
     private $cachetable;

--- a/classes/moodledbjsoncache.php
+++ b/classes/moodledbjsoncache.php
@@ -23,9 +23,6 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-defined('MOODLE_INTERNAL') || die();
-
 class moodledbjsoncache {
 
     private $cachetable;

--- a/classes/moodlefilecache.php
+++ b/classes/moodlefilecache.php
@@ -23,9 +23,6 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-defined('MOODLE_INTERNAL') || die();
-
 class moodlefilecache {
 
     private $cache;

--- a/classes/pluginwrapperconfigurationupdater.php
+++ b/classes/pluginwrapperconfigurationupdater.php
@@ -29,7 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/filter/wiris/integration/lib/com/wiris/plugin/configuration/ConfigurationUpdater.interface.php');
 
-class filter_wiris_pluginwrapperconfigurationupdater implements com_wiris_plugin_configuration_ConfigurationUpdater{
+class filter_wiris_pluginwrapperconfigurationupdater implements com_wiris_plugin_configuration_ConfigurationUpdater {
 
     private $customconfig;
 

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -21,10 +21,7 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
 namespace filter_wiris\privacy;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Privacy Subsystem for filter_wiris implementing null_provider.

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -22,9 +22,6 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-defined('MOODLE_INTERNAL') || die();
-
 function xmldb_filter_wiris_upgrade($oldversion) {
     global $DB, $CFG;
 

--- a/lib.php
+++ b/lib.php
@@ -23,8 +23,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Return an array with the position of the tags named $name on $code variable.
  * @param  String  $code       html code.

--- a/subfilters/client.php
+++ b/subfilters/client.php
@@ -24,11 +24,6 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-
-defined('MOODLE_INTERNAL') || die();
-
-
 class filter_wiris_client extends moodle_text_filter {
 
     /**

--- a/subfilters/php.php
+++ b/subfilters/php.php
@@ -25,11 +25,6 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-
-defined('MOODLE_INTERNAL') || die();
-
-
 class filter_wiris_php extends moodle_text_filter {
 
     /**

--- a/tests/filter_performance_png_test.php
+++ b/tests/filter_performance_png_test.php
@@ -22,15 +22,14 @@
  * @copyright  2016
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
-
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/filter/wiris/filter.php');
 require_once($CFG->dirroot . '/filter/wiris/integration/lib/com/wiris/system/CallWrapper.class.php');
 
-class filter_wiris_filter_performance_png_testcase extends advanced_testcase
-{   protected $wirisfilter;
+class filter_performance_png_test extends advanced_testcase {
+    protected $wirisfilter;
     protected $safexml;
     protected $xml;
     protected $imagepng;

--- a/tests/filter_performance_svg_test.php
+++ b/tests/filter_performance_svg_test.php
@@ -22,15 +22,14 @@
  * @copyright  2016
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
-
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/filter/wiris/filter.php');
 require_once($CFG->dirroot . '/filter/wiris/integration/lib/com/wiris/system/CallWrapper.class.php');
 
-class filter_wiris_filter_performance_svg_testcase extends advanced_testcase
-{   protected $wirisfilter;
+class filter_performance_svg_test extends advanced_testcase {
+    protected $wirisfilter;
     protected $safexml;
     protected $xml;
     protected $image;

--- a/tests/filter_without_performance_png_test.php
+++ b/tests/filter_without_performance_png_test.php
@@ -22,14 +22,13 @@
  * @copyright  2016
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
-
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/filter/wiris/filter.php');
 
-class filter_wiris_filter_noperformance_png_testcase extends advanced_testcase
-{   protected $wirisfilter;
+class filter_without_performance_png_test extends advanced_testcase {
+    protected $wirisfilter;
     protected $safexml;
     protected $xml;
     protected $image;

--- a/tests/filter_without_performance_svg_test.php
+++ b/tests/filter_without_performance_svg_test.php
@@ -22,14 +22,13 @@
  * @copyright  2016
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
-
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/filter/wiris/filter.php');
 
-class filter_wiris_filter_noperformance_svg_testcase extends advanced_testcase
-{   protected $wirisfilter;
+class filter_without_performance_svg_test extends advanced_testcase {
+    protected $wirisfilter;
     protected $safexml;
     protected $xml;
     protected $instance;


### PR DESCRIPTION
## Description
The dependency moodle-plugin-ci that we use to test and analyze our Moodle suit projects code, has been updated to 3.2.3, introducing the following changes:

- PHP_CodeSniffer upgraded to 3.6.2 release (see: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.6.2)
- Report unexpected MOODLE_INTERNAL uses (see: https://github.com/moodlehq/moodle-local_codechecker/pull/169)

This change affects directly to our GitHub Actions workflow, it makes it fail, hence it does not allow us to make new releases of the Moodle suite.

### Implementation:
The new release of the moodle-plugin-ci dependency claims that, all PHP files without side-effects must remove unnecessary `MOODLE_INTERNAL` requirements.

```php
defined('MOODLE_INTERNAL') || die();
```

### What is included on this PR:
This PR also includes:

- There are also other linting issues that can cause errors, so they were removed:
  - Open brackets can not start in a new line.
  - PHP classes must have the same name as the file.
  - Remove unnecessary space & jump spaces.
- Updated CHANGELOG

## Steps to reproduce

- On the Actions tab, find the "Moodle Plugin CI" workflow.
- Use the workflow dispatch option on the KB-19424 branch.
- All moodle code checker verifications should pass without warnings or errors.

[Check Github actions results.](https://github.com/wiris/moodle-filter_wiris/actions/runs/1712206461)

---
[#taskid 19424](https://wiris.kanbanize.com/ctrl_board/2/cards/19487/details/)