### PR TITLE
Github Action step "PHPUnit test" from Moodle-filter not being run on 310 and 311 Moodle branches

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -192,7 +192,7 @@ jobs:
       # 5.4. Code testing
       # Run PHPUnit tests on Moodle3_9 only, for the moment.
       - name: PHPUnit tests
-        if: ${{ matrix.moodle-branch != 'MOODLE_311_STABLE' && matrix.moodle-branch != 'MOODLE_310_STABLE' }}
+        if: ${{ always() }}
         run: moodle-plugin-ci phpunit
       # Run Behat tests on all Moodle branches.
       - name: Behat features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this plugin is 7.27.1 (9th of nov. 2021).
 
+## [Unreleased]
+- fix(ci): moodle code checker warning and errors #19424.
+
 ## v7.27.1 - 9th nov. 2021
 - Fix "missing ['privacy:metadata']" from @christina-roperto contribution #86
 - Improve the "MathType Moodle Plugins Suite" software development cycle.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Last release of this plugin is 7.27.1 (9th of nov. 2021).
 
 ## [Unreleased]
 - fix(ci): moodle code checker warning and errors #19424.
+- fix: pass sucessfully phpunit test for moodle 310 and 311
 
 ## v7.27.1 - 9th nov. 2021
 - Fix "missing ['privacy:metadata']" from @christina-roperto contribution #86

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,180 @@
+# Contributing
+
+We would love for you to contribute to this project and help make it better.
+
+As a contributor, here are the guidelines we would like you to follow:
+
+- [Questions or problems?](#questions-or-problems)
+- [Reporting issues](#reporting-issues)
+- [Coding Rules](#coding-rules)
+- [Commit Message Guidelines](#commit-message-guidelines)
+
+## Questions or problems
+
+Do not open issues for general support questions as we want to keep GitHub issues for bug reports and feature requests.
+
+Instead, we recommend you sending an e-mail to [support@wiris.com](mailto:support@wiris.com) to ask support-related questions.
+
+## Reporting issues
+
+If you find a bug in the source code, you can help us by [submitting an issue](#submitting-an-issue) to our [GitHub Repository][github]. Even better, you can submit a Pull Request with a fix.
+
+### Submitting an Issue
+
+Before you submit an issue, please search the issue tracker. An issue for your problem might already exist and the discussion might inform you of workarounds readily available.
+
+We want to fix all the issues as soon as possible, but before fixing a bug, we need to reproduce and confirm it.
+
+In order to reproduce bugs, we require that you provide a minimal reproduction.
+Having a minimal reproducible scenario gives us a wealth of important information without going back and forth to you with additional questions.
+
+A minimal reproduction allows us to quickly confirm a bug (or point out a coding problem) as well as confirm that we are fixing the right problem.
+
+We require a minimal reproduction to save maintainers' time and ultimately be able to fix more bugs.
+Often, developers find coding problems themselves while preparing a minimal reproduction.
+We understand that sometimes it might be hard to extract essential bits of code from a larger codebase but we really need to isolate the problem before we can fix it.
+
+Unfortunately, we are not able to investigate / fix bugs without a minimal reproduction, so if we don't hear back from you, we are going to close an issue that doesn't have enough info to be reproduced.
+
+You can file new issues by selecting from our [new issue templates](https://github.com/wiris/moodle-filter_wiris/issues/new/choose) and filling out the issue template.
+
+## Coding Rules
+
+To ensure consistency throughout the source code, keep these rules in mind as you are working:
+
+- Follow the [Commit Message Format guidelines](#commit-message-format).
+- Lint all code.
+- Once forked the project, create a new branch from `main` branch.
+
+## Commit Message Guidelines
+
+We have very precise rules over how our Git commit messages must be formatted.
+This format leads to **easier to read commit history**.
+
+> **Note**: You don't need to use this specification to contribute to this project, but we encourage you to do, so.
+
+- Wrap message lines to about 72 characters or so.
+
+- Each commit message consists of a **header**, a **body**, and a **footer**.
+
+```
+<header>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+- The `header` is mandatory and must conform to the [Commit Message Header](#commit-message-header) format.
+
+- The `body` is mandatory for all commits except for those of type "docs".
+  When the body is present it must be at least 20 characters long and must conform to the [Commit Message Body](#commit-message-body) format.
+
+- The `footer` is optional. The [Commit Message Footer](#commit-message-footer) format describes what the footer is used for and the structure it must have.
+
+### Commit Message Header
+
+The commit message `header` should be structured as follows:
+
+```
+<type>(<scope>): <summary>
+  │       │             │
+  │       │             └─> Summary in present tense. Not capitalized. No period at the end.
+  │       │
+  │       └─> Commit Scope (optional): plugin|packaging|changelog|dev-infra|none
+  │
+  └─> Commit Type: build|ci|docs|feat|fix|perf|refactor|test
+```
+
+- The `<type>` and `<summary>` fields are mandatory.
+- The `(<scope>)` field is optional.
+
+#### Type
+
+The recommended default values for `<type>` are the following:
+
+- `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm).
+- `ci`: Changes to our CI configuration files and scripts (examples: GitHub, Jenkins).
+- `docs`: Documentation only changes.
+- `feat`: A new feature.
+- `fix`: A bug fix.
+- `perf`: A code change that improves performance.
+- `refactor`: A code change that neither fixes a bug nor adds a feature.
+- `test`: Adding missing tests or correcting existing tests.
+
+#### Scope
+
+Allowed values:
+
+- `plugin`: used when the plugin's code.
+
+- `packaging`: used for changes that change the npm package layout in all of our packages, e.g. public path changes, package.json changes done to all packages, d.ts file/format changes, changes to bundles, etc.
+
+- `changelog`: used for updating the release notes in CHANGELOG.md
+
+- `dev-infra`: used for dev-infra related changes within the directories /scripts and /tools
+
+- `none` or empty string: useful for `test` and `refactor` changes that are done across all packages (e.g. `test: add missing unit tests`) and for docs changes that are not related to a specific package (e.g. `docs: fix typo in tutorial`).
+
+#### Summary
+
+Use the `<summary>` field to provide a succinct description of the change:
+
+- use the imperative, present tense: "change" not "changed" nor "changes".
+- don't capitalize the first letter.
+- no dot (.) at the end.
+
+### Commit Message Body
+
+Explain the motivation for the change in the commit message `body`.
+
+Just as in the `<summary>`, use the imperative, present tense: "fix" not "fixed" nor "fixes".
+
+This commit message should explain _why_ you are making the change.
+You can include a comparison of the previous behavior with the new behavior in order to illustrate the impact of the change.
+
+### Commit Message Footer
+
+The `footer` can contain information about breaking changes and deprecations and is also the place to reference GitHub issues, Kanbanize card, Jira tickets, and other PRs that this commit closes or is related to.
+
+In the case of Kanbanize, it is compulsory to add `#taskid {card_number}` to allow kanbanize to track commits.
+
+For example:
+
+```
+BREAKING CHANGE: <breaking change summary>
+<BLANK LINE>
+<breaking change description + migration instructions>
+<BLANK LINE>
+<BLANK LINE>
+Fixes #{issue_number}
+#taskid {card_number}
+```
+
+or
+
+```
+DEPRECATED: <what is deprecated>
+<BLANK LINE>
+<deprecation description + recommended update path>
+<BLANK LINE>
+<BLANK LINE>
+Closes #{pull_number}
+#taskid {card_number}
+```
+
+Breaking Change section should start with the phrase `"BREAKING CHANGE: "` followed by a summary of the breaking change, a blank line, and a detailed description of the breaking change that also includes migration instructions.
+
+Similarly, a Deprecation section should start with `"DEPRECATED: "` followed by a short description of what is deprecated, a blank line, and a detailed description of the deprecation that also mentions the recommended update path.
+
+## Revert commits
+
+If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit.
+
+The content of the commit message body should contain:
+
+- information about the SHA of the commit being reverted in the following format: `This reverts commit <SHA>`,
+- a clear description of the reason for reverting the commit message.
+
+[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/
+[github]: https://github.com/wiris/moodle-filter_wiris

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![MathType](./pix/logo-mathtype.png)  MathType Moodle filter plugin by WIRIS
+# ![MathType](./pix/logo-mathtype.png) MathType Moodle filter plugin by WIRIS
 
 [![Moodle Plugin CI](https://github.com/wiris/moodle-filter_wiris/actions/workflows/moodle-ci.yml/badge.svg)](https://github.com/wiris/moodle-filter_wiris/actions/workflows/moodle-ci.yml)
 
@@ -35,6 +35,12 @@ This plugin uses the **MathType Web Integration JavaScript SDK** ([@wiris/html-i
 > The library's source code can be found at [@wiris/html-integrations](https://www.github.com/wiris/html-integrations) repository
 
 **Note:** More details on the `thirdpartylibs.xml` file.
+
+## Contributing
+
+We would love for you to contribute to this project and help make it better.
+
+As a contributor, the guidelines we would like you to follow are documented in the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
 ## Technical Support
 

--- a/classes/moodledbcache.php
+++ b/classes/moodledbcache.php
@@ -23,9 +23,6 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-defined('MOODLE_INTERNAL') || die();
-
 class moodledbcache {
 
     private $cachetable;

--- a/classes/moodledbjsoncache.php
+++ b/classes/moodledbjsoncache.php
@@ -23,9 +23,6 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-defined('MOODLE_INTERNAL') || die();
-
 class moodledbjsoncache {
 
     private $cachetable;

--- a/classes/moodlefilecache.php
+++ b/classes/moodlefilecache.php
@@ -23,9 +23,6 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-defined('MOODLE_INTERNAL') || die();
-
 class moodlefilecache {
 
     private $cache;

--- a/classes/pluginwrapperconfigurationupdater.php
+++ b/classes/pluginwrapperconfigurationupdater.php
@@ -29,7 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/filter/wiris/integration/lib/com/wiris/plugin/configuration/ConfigurationUpdater.interface.php');
 
-class filter_wiris_pluginwrapperconfigurationupdater implements com_wiris_plugin_configuration_ConfigurationUpdater{
+class filter_wiris_pluginwrapperconfigurationupdater implements com_wiris_plugin_configuration_ConfigurationUpdater {
 
     private $customconfig;
 

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -21,10 +21,7 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
 namespace filter_wiris\privacy;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Privacy Subsystem for filter_wiris implementing null_provider.

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -22,9 +22,6 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-defined('MOODLE_INTERNAL') || die();
-
 function xmldb_filter_wiris_upgrade($oldversion) {
     global $DB, $CFG;
 

--- a/lib.php
+++ b/lib.php
@@ -23,8 +23,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Return an array with the position of the tags named $name on $code variable.
  * @param  String  $code       html code.

--- a/subfilters/client.php
+++ b/subfilters/client.php
@@ -24,11 +24,6 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-
-defined('MOODLE_INTERNAL') || die();
-
-
 class filter_wiris_client extends moodle_text_filter {
 
     /**

--- a/subfilters/php.php
+++ b/subfilters/php.php
@@ -25,11 +25,6 @@
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-
-defined('MOODLE_INTERNAL') || die();
-
-
 class filter_wiris_php extends moodle_text_filter {
 
     /**

--- a/tests/filter_performance_png_test.php
+++ b/tests/filter_performance_png_test.php
@@ -34,7 +34,7 @@ class filter_performance_png_test extends advanced_testcase {
     protected $xml;
     protected $imagepng;
 
-    protected function setUp() {
+    protected function setUp(): void {
         global $CFG;
         parent::setUp();
         $this->resetAfterTest(true);

--- a/tests/filter_performance_png_test.php
+++ b/tests/filter_performance_png_test.php
@@ -22,15 +22,14 @@
  * @copyright  2016
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
-
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/filter/wiris/filter.php');
 require_once($CFG->dirroot . '/filter/wiris/integration/lib/com/wiris/system/CallWrapper.class.php');
 
-class filter_wiris_filter_performance_png_testcase extends advanced_testcase
-{   protected $wirisfilter;
+class filter_performance_png_test extends advanced_testcase {
+    protected $wirisfilter;
     protected $safexml;
     protected $xml;
     protected $imagepng;

--- a/tests/filter_performance_svg_test.php
+++ b/tests/filter_performance_svg_test.php
@@ -35,7 +35,7 @@ class filter_performance_svg_test extends advanced_testcase {
     protected $image;
     protected $cachetable;
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
         filter_wiris_pluginwrapper::set_configuration(array('wirispluginperformance' => 'true',

--- a/tests/filter_performance_svg_test.php
+++ b/tests/filter_performance_svg_test.php
@@ -22,15 +22,14 @@
  * @copyright  2016
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
-
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/filter/wiris/filter.php');
 require_once($CFG->dirroot . '/filter/wiris/integration/lib/com/wiris/system/CallWrapper.class.php');
 
-class filter_wiris_filter_performance_svg_testcase extends advanced_testcase
-{   protected $wirisfilter;
+class filter_performance_svg_test extends advanced_testcase {
+    protected $wirisfilter;
     protected $safexml;
     protected $xml;
     protected $image;

--- a/tests/filter_without_performance_png_test.php
+++ b/tests/filter_without_performance_png_test.php
@@ -35,7 +35,7 @@ class filter_without_performance_png_test extends advanced_testcase {
     protected $instance;
     protected $cachetable;
 
-    protected function setUp() {
+    protected function setUp(): void {
         global $CFG;
         parent::setUp();
         $this->resetAfterTest(true);

--- a/tests/filter_without_performance_png_test.php
+++ b/tests/filter_without_performance_png_test.php
@@ -22,14 +22,13 @@
  * @copyright  2016
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
-
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/filter/wiris/filter.php');
 
-class filter_wiris_filter_noperformance_png_testcase extends advanced_testcase
-{   protected $wirisfilter;
+class filter_without_performance_png_test extends advanced_testcase {
+    protected $wirisfilter;
     protected $safexml;
     protected $xml;
     protected $image;

--- a/tests/filter_without_performance_svg_test.php
+++ b/tests/filter_without_performance_svg_test.php
@@ -22,14 +22,13 @@
  * @copyright  2016
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
-
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/filter/wiris/filter.php');
 
-class filter_wiris_filter_noperformance_svg_testcase extends advanced_testcase
-{   protected $wirisfilter;
+class filter_without_performance_svg_test extends advanced_testcase {
+    protected $wirisfilter;
     protected $safexml;
     protected $xml;
     protected $instance;

--- a/tests/filter_without_performance_svg_test.php
+++ b/tests/filter_without_performance_svg_test.php
@@ -33,7 +33,7 @@ class filter_without_performance_svg_test extends advanced_testcase {
     protected $xml;
     protected $instance;
 
-    protected function setUp() {
+    protected function setUp(): void {
         global $CFG;
         parent::setUp();
         $this->resetAfterTest(true);


### PR DESCRIPTION
## Description 

In the moodle-ci.yml file, the `PHPUnit test` step doesn't run with the branches **MOODLE_310_STABLE** or **MOODLE_311_STABLE**.

In this PR, the `if` condition that prevents to run the step, have been modified to pass on all branches. Also, I added `: void`  behind the  `setUp()`  function from files:

- filter_performance_png_test.php
- filter_performance_svg_test.php
- filter_without_performance_png_test.php
- filter_without_performance_svg_test.php

This is necessary to pass the `PHPUnit test` on moodle versions `310` and `311` successfully.

## Steps to reproduce 
1. Go to the [moodle-filter_wiris](https://github.com/wiris/moodle-filter_wiris/runs/5215618071?check_suite_focus=true) GitHub repository.
2. Go to the Actions section.
3. Go to the Moodle Plugin CI workflow.
4. Click on button  Run workflow , select branch that want to test the bug.
5. Wait until execution ends.
6. Click on the workflow run and check the  Annotations  section.

---
[#taskid 20929](https://wiris.kanbanize.com/ctrl_board/2/cards/20929/details/)