### PR TITLE
Filter plugin behat tests compatibility with Moodle 4.0 

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -29,7 +29,7 @@ jobs:
     services:
       # The test will be scoped to postgres only.
       postgres:
-        image: postgres:9.6
+        image: postgres:10
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.1','7.4']
-        moodle-branch: ['MOODLE_35_STABLE', 'MOODLE_36_STABLE', 'MOODLE_37_STABLE', 'MOODLE_38_STABLE', 'MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE']
+        moodle-branch: ['MOODLE_35_STABLE', 'MOODLE_36_STABLE', 'MOODLE_37_STABLE', 'MOODLE_38_STABLE', 'MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'master']
         database: [pgsql]
         # browser: ['firefox', 'chrome']
         exclude:
@@ -62,6 +62,8 @@ jobs:
           - moodle-branch: 'MOODLE_310_STABLE'
             php: '7.1'
           - moodle-branch: 'MOODLE_311_STABLE'
+            php: '7.1'
+          - moodle-branch: 'master'
             php: '7.1'
           - moodle-branch: 'MOODLE_35_STABLE'
             php: '7.4'
@@ -190,7 +192,7 @@ jobs:
       #   run : "ls -la $GITHUB_WORKSPACE"
 
       # 5.4. Code testing
-      # Run PHPUnit tests on Moodle3_9 only, for the moment.
+      # Run PHPUnit tests on all Moodle branches.
       - name: PHPUnit tests
         if: ${{ always() }}
         run: moodle-plugin-ci phpunit

--- a/tests/behat/checkThirdPartyLibs.feature
+++ b/tests/behat/checkThirdPartyLibs.feature
@@ -9,8 +9,7 @@ I need to Check if MathType integration appears on third party libraries page
 
   @javascript
   Scenario: Check third party libraries
-    And I navigate to "Development" in site administration
-    And I follow "Third party libraries"
+    And I navigate to "Development > Third party libraries" in site administration
     Then "MathType Web Integration PHP library" "text" should exist
     Then "MathType Web Integration JavaScript SDK" "text" should exist
     And "GPL 3.0+" "text" should exist

--- a/tests/behat/servicesNotLogged.feature
+++ b/tests/behat/servicesNotLogged.feature
@@ -13,28 +13,28 @@ I can't access the services if service provider is enablabed
   Scenario: configurationjs.php
     And I go to link "/filter/wiris/integration/configurationjs.php?lang=en"
     Then "editorEnabled" "text" should not exist
-    And "Forgotten your username" "text" should exist
+    And "Log in as a guest" "text" should exist
 
   @javascript
   Scenario: createimage.php
     And I go to link "/filter/wiris/integration/createimage.php?mml=<math><mo>x</mo></math>&lang=en"
     Then "formula" "text" should not exist
-    And "Forgotten your username" "text" should exist
+    And "Log in as a guest" "text" should exist
 
   @javascript
   Scenario: showimage.php
     And I go to link "/filter/wiris/integration/showimage.php?mml=<math><mo>x</mo></math>&lang=en"
     Then "status" "text" should not exist
-    And "Forgotten your username" "text" should exist
+    And "Log in as a guest" "text" should exist
 
   @javascript
   Scenario: service.php
     And I go to link "/filter/wiris/integration/service.php?service=mathml2accessible&mml=<math xmlns='http://www.w3.org/1998/Math/MathML'><mn>1</mn><mo>+</mo><mn>2</mn></math>&lang=en"
     Then "status" "text" should not exist
-    And "Forgotten your username" "text" should exist
+    And "Log in as a guest" "text" should exist
 
   @javascript
   Scenario: test.php
     And I go to link "/filter/wiris/integration/test.php?lang=en"
     Then "MathType integration test page" "text" should not exist
-    And "Forgotten your username" "text" should exist
+    And "Log in as a guest" "text" should exist

--- a/tests/behat/testClientRender.feature
+++ b/tests/behat/testClientRender.feature
@@ -28,6 +28,7 @@ I need to change the render type
       | Name | Test MathType for Atto and client side rendering on Moodle |
     And I press "MathType" in "Page content" field in Atto editor
     And I set MathType formula to '<math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><mrow><mo>(</mo><mfrac><mi>p</mi><mn>2</mn></mfrac><mo>)</mo></mrow><msup><mi>x</mi><mn>2</mn></msup><msup><mi>y</mi><mrow><mi>p</mi><mo>-</mo><mn>2</mn></mrow></msup><mo>-</mo><mfrac><mn>1</mn><mrow><mn>1</mn><mo>-</mo><mi>x</mi></mrow></mfrac><mfrac><mn>1</mn><mrow><mn>1</mn><mo>-</mo><msup><mi>x</mi><mn>2</mn></msup></mrow></mfrac></mrow></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "Save and display"
     # // We choosed to use the one-step option.

--- a/tests/behat/testConnectionSettings.feature
+++ b/tests/behat/testConnectionSettings.feature
@@ -8,8 +8,7 @@ I can't access the test service if the service host doesn't exists
   Scenario: Set an incorrect service
     Given the "wiris" filter is "on"
     And I log in as "admin"
-    And I navigate to "Plugins" in site administration
-    And I follow "MathType by WIRIS"
+    And I navigate to "Plugins > MathType by WIRIS" in site administration
     And I set the following fields to these values:
       | Service host | www.wipis.net |
     And I press "Save changes"

--- a/tests/behat/testImageFormat.feature
+++ b/tests/behat/testImageFormat.feature
@@ -16,8 +16,7 @@ I need to see the correct image format
     And I go to link "/filter/wiris/integration/test.php"
     Then MathType formula in svg format is correctly displayed
     And I go back
-    And I navigate to "Plugins" in site administration
-    And I follow "MathType by WIRIS"
+    And I navigate to "Plugins > MathType by WIRIS" in site administration
     And I set the following fields to these values:
       | Image format | png |
     And I press "Save changes"

--- a/tests/behat/testPerformanceDisabled.feature
+++ b/tests/behat/testPerformanceDisabled.feature
@@ -19,8 +19,7 @@ I must not see any JSON response for images services
 
   @javascript
   Scenario: Create image in both formats and check
-    And I navigate to "Plugins" in site administration
-    And I follow "MathType by WIRIS"
+    And I navigate to "Plugins > MathType by WIRIS" in site administration
     And I check image performance mode off
     And I press "Save changes"
     And I am on "Course 1" course homepage with editing mode on
@@ -29,13 +28,13 @@ I must not see any JSON response for images services
       | Name | Test MathType for Atto on Moodle |
     And I press "MathType" in "Page content" field in Atto editor
     And I set MathType formula to '<math><msqrt><mi>x</mi></msqrt></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I check if MathType formula src is equals to 'http://localhost:8000/filter/wiris/integration/showimage.php?formula=44f73ec2e9d0d59f10516949d446049e&cw=27&ch=19&cb=16'
     And I go to link "/filter/wiris/integration/showimage.php?formula=44f73ec2e9d0d59f10516949d446049e&cw=27&ch=19&cb=16"
     Then an svg image is correctly displayed
     And I go back
-    And I navigate to "Plugins" in site administration
-    And I follow "MathType by WIRIS"
+    And I navigate to "Plugins > MathType by WIRIS" in site administration
     And I set the following fields to these values:
       | Image format | png |
     And I press "Save changes"
@@ -45,6 +44,7 @@ I must not see any JSON response for images services
       | Name | Test MathType for Atto on Moodle |
     And I press "MathType" in "Page content" field in Atto editor
     And I set MathType formula to '<math><msqrt><mi>x</mi></msqrt></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I check if MathType formula src is equals to 'http://localhost:8000/filter/wiris/integration/showimage.php?formula=44f73ec2e9d0d59f10516949d446049e&cw=27&ch=19&cb=16'
     And I go to link "/filter/wiris/integration/showimage.php?formula=44f73ec2e9d0d59f10516949d446049e&cw=27&ch=19&cb=16"

--- a/tests/behat/testServerRenderSVG.feature
+++ b/tests/behat/testServerRenderSVG.feature
@@ -27,6 +27,7 @@ I need to change the render type
       | Name | Test MathType for Atto and server side rendering on Moodle |
     And I press "MathType" in "Page content" field in Atto editor
     And I set MathType formula to '<math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><mrow><mo>(</mo><mfrac><mi>p</mi><mn>2</mn></mfrac><mo>)</mo></mrow><msup><mi>x</mi><mn>2</mn></msup><msup><mi>y</mi><mrow><mi>p</mi><mo>-</mo><mn>2</mn></mrow></msup><mo>-</mo><mfrac><mn>1</mn><mrow><mn>1</mn><mo>-</mo><mi>x</mi></mrow></mfrac><mfrac><mn>1</mn><mrow><mn>1</mn><mo>-</mo><msup><mi>x</mi><mn>2</mn></msup></mrow></mfrac></mrow></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "Save and display"
     Then Wirisformula should exist


### PR DESCRIPTION
## Description 
The main goal of this task is to make all Behat test compatible with Moodle 4.0 branch. Also the tests are compatible with the previous Moodle (3.x)  supported  version.

## How to reproduce:

1. Go to [moodle-filter_wiris github repository Actions section.](https://github.com/wiris/moodle-filter_wiris/actions)
3. Select the `Moodle Plugin CI` workflow.
4. Click on `Run workflow` and select the branch `moodle40`.
5. Click on the `Run workflow` green button.

---

[#taskid 21988](https://wiris.kanbanize.com/ctrl_board/2/cards/21988/details/)