### PR TITLE
Update Behat step function i_press_in_field_in_atto_editor to press Collapse button

### DIFF
--- a/tests/behat/behat_wiris_page.php
+++ b/tests/behat/behat_wiris_page.php
@@ -167,6 +167,7 @@ class behat_wiris_page extends behat_wiris_base {
         $buttonarray = array(
             "MathType" => "atto_wiris_button_wiris_editor",
             "ChemType" => "atto_wiris_button_wiris_chem_editor",
+            "Collapse" => "atto_collapse_button",
             "HTML" => "atto_html_button",
             "HTML pressed" => "atto_html_button"
         );


### PR DESCRIPTION
## Description 

Update Behat step function `i_press_in_field_in_atto_editor` to being able to press the Collapse button from Atto Editor.
Used on the `moodle-atto_wiris` feature: `atto_collapseCompatibility.feature`

---

[#taskid 22246](https://wiris.kanbanize.com/ctrl_board/2/cards/22246/details/)