### PR TITLE
fix: Stop using obsolete EReg in transpiled PHP 

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -49,6 +49,16 @@ class filter_wiris extends moodle_text_filter {
                 $subfilter = new filter_wiris_php($this->context, $this->localconfig);
             break;
         }
+
+        // Our custom Haxe-transpiled EReg was obsolete, so we have to do a replacement that used to happen in
+        // filterMath here instead.
+        // This fixes the xmlns=¨http://www.w3.org/1998/Math/MathML¨ being converted into a link by the
+        // "Convert URLs into links and images" filter by Moodle when it is applied before the Wiris filter.
+        // Looks for every SafeXML instance, and within there, removes the surrounding <a>...</a>.
+        $text = preg_replace_callback('/«math.*?«\\/math»/', function ($matches) {
+            return preg_replace('/<a href="[^\"]*"[^>]*>([^<]*)<\\/a>|<a href="[^\"]*">/', '$1', $matches[0]);
+        }, $text);
+
         return $subfilter->filter($text, $options);
     }
 }

--- a/integration/lib/com/wiris/plugin/impl/TextFilter.class.php
+++ b/integration/lib/com/wiris/plugin/impl/TextFilter.class.php
@@ -6,7 +6,6 @@ class com_wiris_plugin_impl_TextFilter {
 		$this->plugin = $plugin;
 		$this->render = $plugin->newRender();
 		$this->service = $plugin->newTextService();
-		$this->fixUrl = null;
 	}}
 	public function save_xml_encode($str) {
 		$tags = com_wiris_plugin_impl_TextFilterTags::newSafeXml();
@@ -123,10 +122,6 @@ class com_wiris_plugin_impl_TextFilter {
 				$n1 = $n1 + strlen($tags->in_appletclose);
 				$sub = _hx_substr($text, $n0, $n1 - $n0);
 				if($safeXML) {
-					if($this->fixUrl === null) {
-						$this->fixUrl = new EReg("<a href=\"[^\"]*\"[^>]*>([^<]*)<\\/a>|<a href=\"[^\"]*\">", "");
-					}
-					$sub = $this->fixUrl->replace($sub, "\$1");
 					$sub = $this->html_entity_decode($sub);
 					$sub = str_replace($tags->in_double_quote, $tags->out_double_quote, $sub);
 					$sub = str_replace($tags->in_open, $tags->out_open, $sub);
@@ -181,10 +176,6 @@ class com_wiris_plugin_impl_TextFilter {
 							}
 						}
 					}
-					if($this->fixUrl === null) {
-						$this->fixUrl = new EReg("<a href=\"[^\"]*\"[^>]*>([^<]*)<\\/a>|<a href=\"[^\"]*\">", "");
-					}
-					$sub = $this->fixUrl->replace($sub, "\$1");
 					$sub = $this->html_entity_decode($sub);
 					$sub = str_replace($tags->in_double_quote, $tags->out_double_quote, $sub);
 					$sub = str_replace($tags->in_open, $tags->out_open, $sub);
@@ -237,7 +228,6 @@ class com_wiris_plugin_impl_TextFilter {
 		$str = $this->filterApplet($tags, $str, $prop, $b);
 		return $str;
 	}
-	public $fixUrl;
 	public $service;
 	public $render;
 	public $plugin;

--- a/tests/behat/behat_wiris_filter.php
+++ b/tests/behat/behat_wiris_filter.php
@@ -90,4 +90,27 @@ class behat_wiris_filter extends behat_wiris_base {
         set_config('editor_enable', $value, 'filter_wiris');
         set_config('chem_editor_enable', $value, 'filter_wiris');
     }
+
+    /**
+     * Makes the given filter the most prioritary one.
+     *
+     * @Given /^the "(?P<filter_name>(?:[^"]|\\")*)" filter has maximum priority$/
+     *
+     * @param string $filtername the name of a filter, e.g. 'glossary'.
+     */
+    public function the_filter_has_max_priority($filtername) {
+        require_once(__DIR__ . '/../../../../lib/filterlib.php');
+
+        // Get all filters
+        $filters = filter_get_global_states();
+        for ($i = $filters[$filtername]->sortorder; $i > 1; $i--) {
+            // We can only move the filter one place at a time
+            // -1 makes it more prioritary
+            filter_set_global_state($filtername, $filters[$filtername]->active, -1);
+        }
+
+        // Reset caches
+        reset_text_filters_cache();
+        core_plugin_manager::reset_caches();
+    }
 }

--- a/tests/behat/urlToLinkFilterCompatibility.feature
+++ b/tests/behat/urlToLinkFilterCompatibility.feature
@@ -1,0 +1,33 @@
+@filter @filter_wiris @wiris_mathtype @onlythisone
+Feature: Compatibility with the Convert URLs into links and images filter by Moodle
+In order to check that the Convert URLs into links and images filter is compatible with the Wiris filter
+As an admin
+I need to enable the Convert URLs into links and images filter and insert a MathType formula
+
+  Background:
+    Given the following config values are set as admin:
+      | config | value | plugin |
+      | toolbar | math = wiris | editor_atto |
+    And the following "courses" exist:
+      | fullname | shortname | format |
+      | Course 1 | C1        | topics |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | admin  | C1     | editingteacher |
+    And the "wiris" filter is "on"
+    And the "urltolink" filter is "on"
+    And the "urltolink" filter has maximum priority
+    And I log in as "admin"
+
+  @javascript
+  Scenario: Insert a formula with the Convert URLs into links and images filter on
+    And I am on "Course 1" course homepage with editing mode on
+    And I add a "Page" to section "0"
+    And I set the following fields to these values:
+      | Name | Insert a formula with the Convert URLs into links and images filter on |
+    And I press "MathType" in "Page content" field in Atto editor
+    And I set MathType formula to '<math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><mrow><mo>(</mo><mfrac><mi>p</mi><mn>2</mn></mfrac><mo>)</mo></mrow><msup><mi>x</mi><mn>2</mn></msup><msup><mi>y</mi><mrow><mi>p</mi><mo>-</mo><mn>2</mn></mrow></msup><mo>-</mo><mfrac><mn>1</mn><mrow><mn>1</mn><mo>-</mo><mi>x</mi></mrow></mfrac><mfrac><mn>1</mn><mrow><mn>1</mn><mo>-</mo><msup><mi>x</mi><mn>2</mn></msup></mrow></mfrac></mrow></math>'
+    And I wait "1" seconds
+    And I press accept button in MathType Editor
+    And I press "Save and display"
+    Then Wirisformula should exist

--- a/thirdpartylibs.xml
+++ b/thirdpartylibs.xml
@@ -3,7 +3,7 @@
     <library>
         <location>integration</location>
         <name>MathType Web Integration PHP library</name>
-        <version>7.28.1</version>
+        <version>7.29.0</version>
         <license>GPL</license>
         <licenseversion>3.0+</licenseversion>
     </library>


### PR DESCRIPTION
Recently, a client complained that the EReg class was raising warnings due to the same-named class being obsolete. We agreed on removing the usage of the class altogether.

EReg is used for pattern matching. Fortunately this was only used in one relevant spot in the Moodle filter integration, making it easy to move the logic from the transpiled part to the PHP native part (see `filter.php`).

To test this change, make sure that the newly added Behat test is well defined and passes correctly, and that the newly implemented code accurately recreates the logic of the old commented code.

Edit: it should be noted that this version of the filter is using a version of the backend integration that is NOT YET published (7.29.0). 