### PR TITLE
fix: Use branch stable as a failsafe in CI

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -133,9 +133,15 @@ jobs:
 
 
       # 3. Install Atto plugin ( and Quizzes ?)
-      - name: Add MathtType plugin for Atto
+      - name: Add MathType plugin for Atto
+        id: install-plugin-atto
+        continue-on-error: true
         run: |
           moodle-plugin-ci add-plugin --branch ${GITHUB_REF##*/} wiris/moodle-atto_wiris
+      - name: Add MathType plugin for Atto using the stable branch
+        if: steps.install-plugin-atto.outcome != 'success'
+        run: |
+          moodle-plugin-ci add-plugin --branch stable wiris/moodle-atto_wiris
 
       # 4. Install Moodle-plugin-ci
       - name: Install moodle-plugin-ci


### PR DESCRIPTION
# Description

Currently, the CI workflow tries to clone other Moodle plugin repos using the same branch as the one it is running on, and fails if it doesn't find such branch.

With this PR, if such branch is not found on the other projects, it defaults to `stable`, thus easing development on issues that affect only a single repository.

# Validation

If you want, you can validate this change following these steps:

- Clone the project and check out this branch (`KB-25037`).
- Check out a new branch from there, with a brand new name.
- Push that branch to GitHub and let it run the CI workflow.
- The workflow should NOT fail due to a missing branch in our other Moodle plugin repos.