### PR TITLE
ci: add moodle 4 on the ci workflow matrix

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.1','7.4']
-        moodle-branch: ['MOODLE_35_STABLE', 'MOODLE_36_STABLE', 'MOODLE_37_STABLE', 'MOODLE_38_STABLE', 'MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'master']
+        moodle-branch: ['MOODLE_35_STABLE', 'MOODLE_36_STABLE', 'MOODLE_37_STABLE', 'MOODLE_38_STABLE', 'MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'master']
         database: [pgsql]
         # browser: ['firefox', 'chrome']
         exclude:
@@ -62,6 +62,8 @@ jobs:
           - moodle-branch: 'MOODLE_310_STABLE'
             php: '7.1'
           - moodle-branch: 'MOODLE_311_STABLE'
+            php: '7.1'
+          - moodle-branch: 'MOODLE_400_STABLE'
             php: '7.1'
           - moodle-branch: 'master'
             php: '7.1'


### PR DESCRIPTION
## Description

This PR replaces the `master` branch with `MOODLE_400_STABLE` in the ci workflow matrix, in order to pass all behat tests in the latest version of moodle.

## How to reproduce:

1. Go to [moodle-filter_wiris github repository Actions section.](https://github.com/wiris/moodle-filter_wiris/actions)
3. Select the `Moodle Plugin CI` workflow.
4. Click on `Run workflow` and select the branch `KB-26099`.
5. Click on the `Run workflow` green button.

---

[#taskid 26096](https://wiris.kanbanize.com/ctrl_board/2/cards/26096/details/)