### PR TITLE
fix: Set default value to PHP for rendertype setting

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.1','7.4']
-        moodle-branch: ['MOODLE_35_STABLE', 'MOODLE_36_STABLE', 'MOODLE_37_STABLE', 'MOODLE_38_STABLE', 'MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'master']
+        moodle-branch: ['MOODLE_35_STABLE', 'MOODLE_36_STABLE', 'MOODLE_37_STABLE', 'MOODLE_38_STABLE', 'MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE']
         database: [pgsql]
         # browser: ['firefox', 'chrome']
         exclude:
@@ -64,8 +64,6 @@ jobs:
           - moodle-branch: 'MOODLE_311_STABLE'
             php: '7.1'
           - moodle-branch: 'MOODLE_400_STABLE'
-            php: '7.1'
-          - moodle-branch: 'master'
             php: '7.1'
           - moodle-branch: 'MOODLE_35_STABLE'
             php: '7.4'

--- a/settings.php
+++ b/settings.php
@@ -114,7 +114,7 @@ if ($ADMIN->fulltree) {
         $settings->add(new admin_setting_configselect('filter_wiris/rendertype',
                                                             get_string('rendertype', 'filter_wiris'),
                                                             get_string('rendertype_help', 'filter_wiris'),
-                                                            'default',
+                                                            'php',
                                                             array('php' => 'PHP', 'client' => 'Client')));
 
         $settings->add(new admin_setting_configselect('filter_wiris/imageformat',


### PR DESCRIPTION
# Description

The old default value for this setting was invalid (it used to say `default`).

# How to reproduce

1. Open a Moodle instance with the filter on this branch.
2. As an admin, go to the Settings > Filters > MathType filter page, and look for the "Render type" setting.
3. It should have a string beside the dropdown box saying "Default: PHP".