### PR TITLE
Update tests for Moodle 4.1

### DIFF
--- a/tests/behat/testClientRender.feature
+++ b/tests/behat/testClientRender.feature
@@ -35,5 +35,6 @@ I need to change the render type
     # // This 2-step other option works also:
     # When I wait until the page is ready
     # Then Wirisformula should exist
+    And I wait "1" seconds
     Then I wait until Wirisformula formula exists
     And MathType formula in svg format is correctly displayed

--- a/tests/behat/testServerRenderPNG.feature
+++ b/tests/behat/testServerRenderPNG.feature
@@ -27,7 +27,9 @@ I need to change the render type
       | Name | Test MathType for Atto and server side rendering on Moodle |
     And I press "MathType" in "Page content" field in Atto editor
     And I set MathType formula to '<math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><mrow><mo>(</mo><mfrac><mi>p</mi><mn>2</mn></mfrac><mo>)</mo></mrow><msup><mi>x</mi><mn>2</mn></msup><msup><mi>y</mi><mrow><mi>p</mi><mo>-</mo><mn>2</mn></mrow></msup><mo>-</mo><mfrac><mn>1</mn><mrow><mn>1</mn><mo>-</mo><mi>x</mi></mrow></mfrac><mfrac><mn>1</mn><mrow><mn>1</mn><mo>-</mo><msup><mi>x</mi><mn>2</mn></msup></mrow></mfrac></mrow></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "Save and display"
+    And I wait "1" seconds
     Then Wirisformula should exist
     And MathType formula in png format is correctly displayed

--- a/tests/behat/testServerRenderSVG.feature
+++ b/tests/behat/testServerRenderSVG.feature
@@ -30,5 +30,6 @@ I need to change the render type
     And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "Save and display"
+    And I wait "1" seconds
     Then Wirisformula should exist
     And MathType formula in svg format is correctly displayed

--- a/tests/behat/urlToLinkFilterCompatibility.feature
+++ b/tests/behat/urlToLinkFilterCompatibility.feature
@@ -30,4 +30,5 @@ I need to enable the Convert URLs into links and images filter and insert a Math
     And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "Save and display"
+    And I wait "1" seconds
     Then Wirisformula should exist


### PR DESCRIPTION
##Description

Moodle is releasing the 4.1 version. This PR includes the changes on the moodle filter tests so that they can be compatible with the latest updates.

## How to reproduce

1. Follow the instructions on the `wiris-moodle-docker` project to create a new moodle with
    * The moodle branch set to `master`.
    * The wiris moodle branch set to `KB-28918`.
2. Run the tests with the tag `filter_wiris`

---

[#taskid 28918](https://wiris.kanbanize.com/ctrl_board/2/cards/28918/details/)