### PR TITLE
Moodle not sending the correct course and category to Telemetry

### DIFF
--- a/classes/configurationupdater.php
+++ b/classes/configurationupdater.php
@@ -191,13 +191,8 @@ class filter_wiris_configurationupdater implements com_wiris_plugin_configuratio
         $configuration['wiriseditorsavemode'] = 'safeXml';
         $configuration['wirishostplatform'] = 'Moodle';
         $configuration['wirisversionplatform'] = $CFG->version;
-        $configuration['wirisversionmoodle'] = $CFG->branch;
         // Referer.
         global $COURSE;
-
-        // $configuration['wiriscategorymoodle'] = $COURSE->category;
-        $configuration['wiriscoursemoodleid'] = $COURSE->id;
-        // $configuration['wiriscoursemoodlename'] = $COURSE->fullname;
 
         $query = '';
         if (isset($COURSE->id)) {

--- a/integration/lib/com/wiris/plugin/impl/ConfigurationImpl.class.php
+++ b/integration/lib/com/wiris/plugin/impl/ConfigurationImpl.class.php
@@ -71,10 +71,6 @@ class com_wiris_plugin_impl_ConfigurationImpl implements com_wiris_plugin_api_Co
 		$javaScriptHash->set("hostPlatform", $this->getProperty("wirishostplatform", null));
 		$javaScriptHash->set("versionPlatform", $this->getProperty("wirisversionplatform", "unknown"));
 		$javaScriptHash->set("enableAccessibility", $this->getProperty("wirisaccessibilityenabled", null) === "true");
-		$javaScriptHash->set("versionMoodle", $this->getProperty("wirisversionmoodle", null));
-		$javaScriptHash->set("categoryMoodle", $this->getProperty("wiriscategorymoodle", null));
-		$javaScriptHash->set("courseMoodleId", $this->getProperty("wiriscoursemoodleid", null));
-		$javaScriptHash->set("courseMoodleName", $this->getProperty("wiriscoursemoodlename", null));
 		$javaScriptHash->set("editorToolbar", $this->getProperty(com_wiris_plugin_api_ConfigurationKeys::$EDITOR_TOOLBAR, null));
 		$javaScriptHash->set("chemEnabled", $this->getProperty("wirischemeditorenabled", null) === "true");
 		$javaScriptHash->set("imageFormat", $this->getProperty("wirisimageformat", "png"));

--- a/integration/lib/default-configuration.ini
+++ b/integration/lib/default-configuration.ini
@@ -45,11 +45,3 @@ wirisaccessproviderenabled = false
 
 # Semantics
 wirissavehandtraces = false
-
-# Version 
-wirisversionmoodle = unknown
-
-# Course data
-wiriscategorymoodle = undefined
-wiriscoursemoodleid = undefined
-wiriscoursemoodlename = undefined


### PR DESCRIPTION
## Description

The Telemetry events were not sending the correct Moodle course and category. Those were sent by the back-end, and were set just once, when the filter is loaded, which caused the values to never change from their original value.

This PR removes the previous way of sending the Moodle course data to Telemetry, which used the backend configuration.

## What needs to be reviewed?

* Validate that there are no configurations defined to send the course data to Telemetry or the front-end.

---

[#taskid 34608](https://wiris.kanbanize.com/ctrl_board/2/cards/34608/details/)