### PR TITLE
[KB-34039] Update how steps output are store in Github actions workflows.

### DIFF
--- a/.github/workflows/moodle-cd.yml
+++ b/.github/workflows/moodle-cd.yml
@@ -42,7 +42,7 @@ jobs:
                                          --data-urlencode "vcstag=${TAGNAME}" \
                                          --data-urlencode "changelogurl=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commits/${TAGNAME}" \
                                          --data-urlencode "altdownloadurl=${ZIPURL}")
-          echo "::set-output name=response::${RESPONSE}"
+          echo "response=${RESPONSE}" >> $GITHUB_OUTPUT
       - name: Evaluate the response
         id: evaluate-response
         env:


### PR DESCRIPTION
In this PR the github actions workflows are updated so the outputs are stored correctly, following these instructions https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Associated KB card: https://wiris.kanbanize.com/ctrl_board/2/cards/34039/details/