### PR TITLE
[KB-37848] Fix bugs when "MathType filter + MathType for TinyMCE 6" installed withour the MathType for ATTO.

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -131,6 +131,17 @@ jobs:
         run: |
           moodle-plugin-ci add-plugin --branch stable wiris/moodle-atto_wiris
 
+      # 3.1 Install Tiny plugin ( and Quizzes ?)
+      - name: Add MathType plugin for TinyMCE
+        id: install-plugin-tiny
+        continue-on-error: true
+        run: |
+          moodle-plugin-ci add-plugin --branch ${GITHUB_REF##*/} wiris/moodle-tinymce_tiny_mce_wiris
+      - name: Add MathType plugin for TinyMCE using the stable branch
+        if: steps.install-plugin-tiny.outcome != 'success'
+        run: |
+          moodle-plugin-ci add-plugin --branch stable wiris/moodle-tinymce_tiny_mce_wiris
+
       # 4. Install Moodle-plugin-ci
       - name: Install moodle-plugin-ci
         run: |
@@ -296,6 +307,17 @@ jobs:
         if: steps.install-plugin-atto.outcome != 'success'
         run: |
           moodle-plugin-ci add-plugin --branch stable wiris/moodle-atto_wiris
+
+      # 3.1 Install Tiny plugin ( and Quizzes ?)
+      - name: Add MathType plugin for TinyMCE
+        id: install-plugin-tiny
+        continue-on-error: true
+        run: |
+          moodle-plugin-ci add-plugin --branch ${GITHUB_REF##*/} wiris/moodle-tiny_wiris
+      - name: Add MathType plugin for TinyMCE using the stable branch
+        if: steps.install-plugin-tiny.outcome != 'success'
+        run: |
+          moodle-plugin-ci add-plugin --branch stable wiris/moodle-tiny_wiris
 
       # 4. Install Moodle-plugin-ci
       - name: Install moodle-plugin-ci

--- a/classes/pluginwrapper.php
+++ b/classes/pluginwrapper.php
@@ -152,7 +152,6 @@ class filter_wiris_pluginwrapper {
                 $editors[] = 'tiny';
             }
         }
-        
 
         foreach ($editors as $editor) {
             if ($editor == 'atto') {

--- a/classes/pluginwrapper.php
+++ b/classes/pluginwrapper.php
@@ -143,9 +143,17 @@ class filter_wiris_pluginwrapper {
         if (!in_array('atto', $editors)) {
             $editors[] = 'atto';
         }
-        if (!in_array('tinymce', $editors)) {
-            $editors[] = 'tinymce';
+        if ($CFG->branch < 402) {
+            if (!in_array('tinymce', $editors)) {
+                $editors[] = 'tinymce';
+            }
+        } else {
+            if (!in_array('tiny', $editors)) {
+                $editors[] = 'tiny';
+            }
         }
+        
+
         foreach ($editors as $editor) {
             if ($editor == 'atto') {
                 $relativepath = '/lib/editor/atto/plugins/wiris';
@@ -157,16 +165,15 @@ class filter_wiris_pluginwrapper {
                     return $plugin;
                 }
             } else if ($editor == 'tinymce') {
-                if ($CFG->version >= 2012120300 && $CFG->branch < 402) { // Location for Moodle 2.4 onwards .
+                if ($CFG->version >= 2012120300) { // Location for Moodle 2.4 onwards .
                     $relativepath = '/lib/editor/tinymce/plugins/tiny_mce_wiris/tinymce';
-                } else if ($CFG->version < 2012120300) { // Location for Moodle < 2.4 .
+                } else { // Location for Moodle < 2.4 .
                     require_once($CFG->dirroot . '/lib/editor/tinymce/lib.php');
                     $tiny = new tinymce_texteditor();
                     $tinyversion = $tiny->version;
                     $relativepath = '/lib/editor/tinymce/tiny_mce/' . $tinyversion . '/plugins/tiny_mce_wiris';
-                } else {
-                    $relativepath = '/lib/editor/tiny/plugins/wiris';
                 }
+
                 if (!file_exists($CFG->dirroot . $relativepath . '/core')) {
                     // MathType  >= 3.50 not installed.
                     continue;
@@ -174,11 +181,19 @@ class filter_wiris_pluginwrapper {
                 $plugin = new stdClass();
                 $plugin->url = $CFG->wwwroot . $relativepath;
                 $plugin->path = $CFG->dirroot . $relativepath;
-                if ($CFG->version >= 2012120300 && $CFG->branch < 402) {
+                if ($CFG->version >= 2012120300) {
                     $plugin->version = get_config('tinymce_tiny_mce_wiris', 'version');
-                } else {
-                    $plugin->version = get_config('tiny_wiris/plugin', 'version');
                 }
+
+                return $plugin;
+            } else if ($editor == 'tiny') {
+                $relativepath = '/lib/editor/tiny/plugins/wiris';
+
+                $plugin = new stdClass();
+                $plugin->url = $CFG->wwwroot . $relativepath;
+                $plugin->path = $CFG->dirroot . $relativepath;
+                $plugin->version = get_config('tiny_wiris/plugin', 'version');
+
                 return $plugin;
             }
         }

--- a/info.php
+++ b/info.php
@@ -64,11 +64,11 @@ function get_current_editor_data($branch, $version, $texteditors) {
     $data = array();
 
     $editors = array_flip(explode(',', $texteditors));
-    $editorCount = count($editors);
+    $editorcount = count($editors);
 
-    if ($editorCount === 0) {
+    if ($editorcount === 0) {
         throw new Exception(get_string('noteditorspluginsinstalled', 'filter_wiris'), 1);
-    } elseif ($editorCount === 1 && array_key_exists('textarea', $editors)) {
+    } else if ($editorcount === 1 && array_key_exists('textarea', $editors)) {
         throw new Exception(get_string('onlytextareaeditorinstalled', 'filter_wiris'), 1);
     }
 
@@ -133,7 +133,7 @@ function check_if_wiris_button_are_in_tinymce_toolbar() {
     }
 }
 
-// Create info table
+// Create info table.
 function create_info_header() {
     $output = html_writer::tag('h1', get_string('title', 'filter_wiris'), array('class' => 'wrs_plugin wrs_filter'));
 
@@ -165,7 +165,7 @@ function create_filter_version_row($solutionlink = null) {
     $plugin = new stdClass();
     require($CFG->dirroot . '/filter/wiris/version.php');
     $testname = get_string('lookingforwirisfilterversion', 'filter_wiris');
-    
+
     if (isset($plugin->release)) {
         $reporttext = $plugin->release;
         $condition = true;
@@ -200,20 +200,22 @@ function create_atto_installed_row($currenteditordata = null, $solutionlink = nu
                     get_string('mustbeinstalled', 'filter_wiris');
     $wirisplugin = $currenteditordata['plugin_path'];
     $condition = file_exists($wirisplugin);
-    
+
     echo html_writer::tag('tr', wrs_createtablerow($testname, $reporttext, $solutionlink, $condition), array('class' => 'wrs_plugin wrs_filter'));
 
     return $condition;
 }
 
 function create_atto_compatibility_row($currenteditordata = null, $solutionlink = null) {
+    global $CFG;
+
+    $plugin = new stdClass();
+    require($CFG->dirroot . '/filter/wiris/version.php');
     $wirisplugin = filter_wiris_pluginwrapper::get_wiris_plugin();
     $testname = get_string('wirispluginfilterfor', 'filter_wiris') . '&nbsp;' . $currenteditordata['plugin_name'] . ' versions';
-    $plugin = new stdClass();
 
-    if (isset($plugin->version)) {
-        $filterversion = $plugin->version;
-    }
+    // Get filter version.
+    $filterversion = isset($plugin->version) ? $plugin->version : '';
 
     // Using version.php to check release number.
     if (strtolower($currenteditordata['plugin_name']) == 'tinymce' || strtolower($currenteditordata['plugin_name']) == 'tiny') {
@@ -322,7 +324,7 @@ if (create_atto_installed_row($currenteditordata, $solutionlink)) {
 // Tiny is installed.
 echo create_tiny_installed_row($solutionlink);
 
-// Close table
+// Close table.
 echo create_table_close();
 
 $output = '';

--- a/lang/en/filter_wiris.php
+++ b/lang/en/filter_wiris.php
@@ -15,6 +15,14 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+/**
+ * Strings for component 'filter_wiris', language 'en'.
+ *
+ * @package    filter
+ * @subpackage wiris
+ * @copyright  WIRIS Europe (Maths for more S.L)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 $string['accessproviderenabled'] = 'Access control';
 $string['accessproviderenabled_help'] = 'If enabled only authenticated users can access MathType services.';
 $string['alloweditorpluginactive'] = 'Editor always active';

--- a/settings.php
+++ b/settings.php
@@ -160,7 +160,7 @@ if ($ADMIN->fulltree) {
                 if ($CFG->branch < 402) {
                     $tinyurl .= 'https://moodle.org/plugins/tinymce_tiny_mce_wiris';
                 } else {
-                    $tinyurl .= 'https://moodle.org/plugins/tiny_wiris';  // TODO, wait until we publish the plugin on moodle.org.
+                    $tinyurl .= 'https://moodle.org/plugins/tiny_wiris';
                 }
                 $attourl = 'https://moodle.org/plugins/atto_wiris';
                 $linkattributes = array('target' => '_blank');

--- a/settings.php
+++ b/settings.php
@@ -160,7 +160,7 @@ if ($ADMIN->fulltree) {
                 if ($CFG->branch < 402) {
                     $tinyurl .= 'https://moodle.org/plugins/tinymce_tiny_mce_wiris';
                 } else {
-                    $tinyurl .= 'https://moodle.org/plugins/tiny_wiris';  // TODO, wait until we publish the plugin on moodle.org
+                    $tinyurl .= 'https://moodle.org/plugins/tiny_wiris';  // TODO, wait until we publish the plugin on moodle.org.
                 }
                 $attourl = 'https://moodle.org/plugins/atto_wiris';
                 $linkattributes = array('target' => '_blank');

--- a/test.php
+++ b/test.php
@@ -1,0 +1,41 @@
+<?php
+function create_atto_compatibility_row($currenteditordata = null, $solutionlink = null) {
+    // Get Wiris plugin instance
+    $wirisplugin = filter_wiris_pluginwrapper::get_wiris_plugin();
+    
+    // Prepare test name
+    $testname = get_string('wirispluginfilterfor', 'filter_wiris') . '&nbsp;' . $currenteditordata['plugin_name'] . ' versions';
+
+    // Get plugin version
+    $pluginversion = '';
+    $versionFile = (strtolower($currenteditordata['plugin_name']) == 'tinymce' || strtolower($currenteditordata['plugin_name']) == 'tiny')
+        ? $currenteditordata['plugin_path'] . '/../version.php'
+        : $currenteditordata['plugin_path'] . '/version.php';
+
+    if (file_exists($versionFile)) {
+        require($versionFile);
+        if (isset($plugin->version)) {
+            $pluginversion = $plugin->version;
+        }
+    }
+
+    // Get filter version
+    $filterversion = isset($plugin->version) ? $plugin->version : '';
+
+    // Check compatibility
+    if ($filterversion == $pluginversion) {
+        $reporttext = get_string('wirispluginfilterfor', 'filter_wiris') . '&nbsp;' . $currenteditordata['plugin_name'] . '&nbsp;' .
+                        get_string('havesameversion', 'filter_wiris');
+        $condition = true;
+    } else {
+        $reporttext = get_string('wirispluginfilterfor', 'filter_wiris') . '&nbsp;' . $currenteditordata['plugin_name'] . '&nbsp;' .
+                        get_string('versionsdontmatch', 'filter_wiris');
+        $reporttext .= "<br>" . get_string('wirisfilterversion', 'filter_wiris') . '&nbsp;' . $filterversion;
+        $reporttext .= "<br>" . get_string('wirispluginfor', 'filter_wiris') . '&nbsp;' .  $currenteditordata['plugin_name'] .
+                        '&nbsp;' . get_string('version', 'filter_wiris'). ' = ' . $pluginversion;
+        $condition = false;
+    }
+
+    // Return the HTML output as a string
+    return html_writer::tag('tr', wrs_createtablerow($testname, $reporttext, $solutionlink, $condition), array('class' => 'wrs_plugin wrs_filter'));
+}

--- a/test.php
+++ b/test.php
@@ -1,28 +1,52 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * MathType filter test page.
+ *
+ * @package    filter
+ * @subpackage wiris
+ * @copyright  WIRIS Europe (Maths for more S.L)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 function create_atto_compatibility_row($currenteditordata = null, $solutionlink = null) {
-    // Get Wiris plugin instance
+    // Get Wiris plugin instance.
     $wirisplugin = filter_wiris_pluginwrapper::get_wiris_plugin();
-    
-    // Prepare test name
+
+    // Prepare test name.
     $testname = get_string('wirispluginfilterfor', 'filter_wiris') . '&nbsp;' . $currenteditordata['plugin_name'] . ' versions';
 
-    // Get plugin version
+    // Get plugin version.
     $pluginversion = '';
-    $versionFile = (strtolower($currenteditordata['plugin_name']) == 'tinymce' || strtolower($currenteditordata['plugin_name']) == 'tiny')
+    $versionfile = (strtolower($currenteditordata['plugin_name']) == 'tinymce' || strtolower($currenteditordata['plugin_name']) == 'tiny')
         ? $currenteditordata['plugin_path'] . '/../version.php'
         : $currenteditordata['plugin_path'] . '/version.php';
 
-    if (file_exists($versionFile)) {
-        require($versionFile);
+    if (file_exists($versionfile)) {
+        require($versionfile);
         if (isset($plugin->version)) {
             $pluginversion = $plugin->version;
         }
     }
 
-    // Get filter version
+    // Get filter version.
     $filterversion = isset($plugin->version) ? $plugin->version : '';
 
-    // Check compatibility
+    // Check compatibility.
     if ($filterversion == $pluginversion) {
         $reporttext = get_string('wirispluginfilterfor', 'filter_wiris') . '&nbsp;' . $currenteditordata['plugin_name'] . '&nbsp;' .
                         get_string('havesameversion', 'filter_wiris');
@@ -36,6 +60,6 @@ function create_atto_compatibility_row($currenteditordata = null, $solutionlink 
         $condition = false;
     }
 
-    // Return the HTML output as a string
+    // Return the HTML output as a string.
     return html_writer::tag('tr', wrs_createtablerow($testname, $reporttext, $solutionlink, $condition), array('class' => 'wrs_plugin wrs_filter'));
 }

--- a/tests/behat/behat_wiris_editor.php
+++ b/tests/behat/behat_wiris_editor.php
@@ -86,7 +86,7 @@ class behat_wiris_editor extends behat_wiris_base {
                 $container = $context->getSession()->getPage()->find('xpath', '//div[@id=\'wrs_modal_dialogContainer[0]\' and
                 @class=\'wrs_modal_dialogContainer wrs_modal_desktop wrs_stack\']//span[@class=\'wrs_container\']');
                 $button = $context->getSession()->getPage()->find('xpath', '//button[@id=\'wrs_modal_button_accept[0]\']');
-                return !empty($toolbar) and !empty($container);
+                return !empty($toolbar) && !empty($container);
             },
             array(),
             self::get_extended_timeout(),
@@ -113,7 +113,7 @@ class behat_wiris_editor extends behat_wiris_base {
                 $container = $context->getSession()->getPage()->find('xpath', '//div[@id=\'wrs_modal_dialogContainer[0]\' and
                 @class=\'wrs_modal_dialogContainer wrs_modal_desktop wrs_stack\']//span[@class=\'wrs_container\']');
                 $button = $context->getSession()->getPage()->find('xpath', '//button[@id=\'wrs_modal_button_accept[0]\']');
-                return !empty($toolbar) and !empty($container);
+                return !empty($toolbar) && !empty($container);
             },
             array(),
             self::get_extended_timeout(),

--- a/tests/behat/behat_wiris_filter.php
+++ b/tests/behat/behat_wiris_filter.php
@@ -101,15 +101,15 @@ class behat_wiris_filter extends behat_wiris_base {
     public function the_filter_has_max_priority($filtername) {
         require_once(__DIR__ . '/../../../../lib/filterlib.php');
 
-        // Get all filters
+        // Get all filters.
         $filters = filter_get_global_states();
         for ($i = $filters[$filtername]->sortorder; $i > 1; $i--) {
             // We can only move the filter one place at a time
-            // -1 makes it more prioritary
+            // -1 makes it more prioritary.
             filter_set_global_state($filtername, $filters[$filtername]->active, -1);
         }
 
-        // Reset caches
+        // Reset caches.
         reset_text_filters_cache();
         core_plugin_manager::reset_caches();
     }


### PR DESCRIPTION
## Description 

This PR fix two bugs when you have a Moodle with MathType for TinyMCE6 without MathType for Atto:

1. The some configuration properties from filter configuration page disappear.
2. The info.php page display three errors because doesn't find the atto plugin.

## Steps to reproduce

1. Open Moodle 4.2 with php 8.2` using wiris-moodle-docker` project.
2. Delete MathType for Atto deleting the folder `<Moodle-path>/lib/editor/atto/plugins/wiris`.
3. Login as admin an go to the [MathType Filter Administration Page](http://localhost:8000/admin/settings.php?section=filtersettingwiris)

All configuration properties must appear

4. Navigate to [http://localhost:8000/filter/wiris/info.php](http://localhost:8000/filter/wiris/info.php)

A table will be rendered as the next image without any warning message on the top of the page

![image](https://github.com/wiris/moodle-filter_wiris/assets/91468181/2bfc1af4-dd06-4084-903d-8f30a02e43ec)

---
[#taskid 37848](https://wiris.kanbanize.com/ctrl_board/2/cards/37848/details/)



