### PR TITLE
feat: add notification tinymce legacy incompatibility

### DIFF
--- a/info.php
+++ b/info.php
@@ -289,6 +289,18 @@ function create_table_close() {
     return $output;
 }
 
+function warning_tiny_incompatibility() {
+    global $CFG;
+
+    if ($CFG->version < 20230424) {
+        return;
+    }
+
+    if (is_dir($CFG->dirroot.'/lib/editor/tinymce/plugins/tiny_mce_wiris')) {
+        \core\notification::warning(get_string('tinymceincompatibility', 'filter_wiris'));
+    }
+}
+
 // Page prologue.
 $PAGE->set_context(context_system::instance());
 $PAGE->set_title(get_string('title', 'filter_wiris'));
@@ -299,6 +311,8 @@ echo $OUTPUT->header();
 $currenteditordata = get_current_editor_data($CFG->branch, $CFG->version, $CFG->texteditors);
 
 $solutionlink = 'https://docs.wiris.com/mathtype/en/mathtype-for-lms/mathtype-for-moodle.html#install-mathtype-for-moodle?utm_source=moodle&utm_medium=referral';
+
+warning_tiny_incompatibility();
 
 // Create info table.
 create_info_header();

--- a/lang/en/filter_wiris.php
+++ b/lang/en/filter_wiris.php
@@ -93,6 +93,7 @@ $string['securitysettings'] = 'Security settings';
 $string['securitysettings_text'] = '';
 $string['title'] = 'MathType filter test page';
 $string['tinymce'] = 'TinyMCE';
+$string['tinymceincompatibility'] = 'MathType for TinyMCE (legacy) is not supported in Moodle 4.2 or higher, you must uninstall the plugin located on "./lib/editor/tinymce/plugins/tiny_mce_wiris" and install the MathType plugin for TinyMCE 6';
 $string['version'] = 'version';
 $string['versionsdontmatch'] = 'versions don\'t match';
 $string['windowsettings'] = 'Window settings';


### PR DESCRIPTION
## Description

This PR add the next warning message on `settings.php` and `info.php` page if the TinyMCE (Legacy) plugins is installed in Moodle version 4.2 or highest.

```
MathType for TinyMCE (legacy) is not supported in Moodle 4.2 or higher, you must uninstall the plugin located on "./lib/editor/tinymce/plugins/tiny_mce_wiris" and install the MathType plugin for TinyMCE 6
```

## Steps to reproduce

1. Open a Moodle 3.10.
2. Increase Moodle version to 4.2
3. Check info.php page (http://localhost:8000/filter/wiris/info.php) If the warning appears.
4. Check info filter settings page (http://localhost:8000/admin/settings.php?section=filtersettingwiris) If the waning appears.
5. On Moodle remove the folder "./lib/editor/tinymce/" folder and check if the warning disappear on info.php and filter settings page.

---

[#taskid 39093](https://wiris.kanbanize.com/ctrl_board/2/cards/39093/details/)