### PR TITLE
Fetch notification when load setting page

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -29,6 +29,8 @@ if ($ADMIN->fulltree) {
     global $CFG;
     global $wirisconfigurationclass;
 
+    \core\notification::fetch();
+
     require_once("$CFG->dirroot/filter/wiris/lib.php");
     // Automatic class loading not avaliable for Moodle 2.4 and 2.5.
     wrs_loadclasses();

--- a/settings.php
+++ b/settings.php
@@ -25,11 +25,16 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+// Moodle notification API: https://docs.moodle.org/dev/Notifications.
+use \core\notification;
+
 if ($ADMIN->fulltree) {
     global $CFG;
     global $wirisconfigurationclass;
 
-    \core\notification::fetch();
+    // Moodle doesn't render page headings on some cases, but saves them for later, causing multiple headings
+    // Using fetch immediately renders without saving.
+    notification::fetch();
 
     require_once("$CFG->dirroot/filter/wiris/lib.php");
     // Automatic class loading not avaliable for Moodle 2.4 and 2.5.
@@ -194,8 +199,7 @@ if ($ADMIN->fulltree) {
 
     if (!empty($warningoutput)) {
         if ($CFG->version > 2016052300) {
-            // Moodle notification API: https://docs.moodle.org/dev/Notifications.
-            \core\notification::warning($warningoutput);
+            notification::warning($warningoutput);
         } else {
             $settings->add(new admin_setting_heading('filter_wiris_old_configuration', '', $warningoutput));
         }


### PR DESCRIPTION
## Description

Fix error for MathType for TinyMCE (legacy) warning, that can be displayed multiple times on the Site administration.

## Steps to reproduce
(If this is your first time running Moodle, please following this instruction to configure: https://github.com/wiris/wiris-moodle-docker/blob/main/README.md)

1. Use Moodle > 4.1.
2. MathType for TinyMCE (legacy) is installed
3. Log in Moodle as an admin
4. Go to Site Administration
5. Go to Plugins > Filter > MathType by WIRIS
6. Change Render Type from Client to PHP.
7. Check that the warning only shows one time

---

[taskid 44423](https://wiris.kanbanize.com/ctrl_board/2/cards/44423/details/)