### PR TITLE
MTMOODLE-30: Fix

### DIFF
--- a/tests/behat/urlToLinkFilterCompatibility.feature
+++ b/tests/behat/urlToLinkFilterCompatibility.feature
@@ -15,7 +15,7 @@ Feature: Compatibility with the Convert URLs into links and images filter by Moo
       | user  | course | role           |
       | admin | C1     | editingteacher |
     And the "wiris" filter is "on"
-    And the "urltolink" filter is "off"
+    And the "urltolink" filter is "on"
     And the "urltolink" filter has maximum priority
     And I log in as "admin"
 


### PR DESCRIPTION
The test is to check that urlToLink is incompatible with MT, but instead of activating it, it was deactivating it.
Tested in 4.3 and it worked (which is unexpected).