### PR TITLE
fix: prevent unnecessary LaTeX rendering during editing context

### DIFF
--- a/subfilters/php.php
+++ b/subfilters/php.php
@@ -92,9 +92,10 @@ class filter_wiris_php extends \core_filters\text_filter {
         if (!$this->mathjax_have_preference() && $wirispluginwrapper->wiris_editor_parse_latex()) {
             foreach ($matches[0] as $latex) {
 
-                // ! Avoid transforming LaTeX in editing context to prevent unnecessary rendering requests.
-                // ! Editors may inject the string "$$\pi$$" during tests, which previously caused excessive rendering requests.
-                // ! This check ensures that the string "$$\pi$$" is not transformed by the service.
+                // ! For some reason, strayed `pi` LaTeX expressions are included in some Moodle pages by default. 
+                // ! This implies our services having to convert them into MathML and then rendering them as an image without the user even interacting with MathType to begin with.
+                // ! To avoid this extra requests, which may impact our services, we just hardcoded it´s conversion to MathML.
+                // ! NOTE: requests to latex2mahtml service aren't cached, worsening this situation.
 
                 if ($latex === '$$\pi$$') {
                     $text = str_replace($latex, '<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>&pi;</mi></math>', $text);

--- a/subfilters/php.php
+++ b/subfilters/php.php
@@ -91,13 +91,14 @@ class filter_wiris_php extends \core_filters\text_filter {
         // If MathJax doesn't have preference and wiriseditorparselatex = true, parse LateX into MathML.
         if (!$this->mathjax_have_preference() && $wirispluginwrapper->wiris_editor_parse_latex()) {
             foreach ($matches[0] as $latex) {
-                $editing = optional_param('action', '', PARAM_ALPHA) === 'edit' || optional_param('update', 0, PARAM_INT) > 0;
 
                 // ! Avoid transforming LaTeX in editing context to prevent unnecessary rendering requests.
                 // ! Editors may inject the string "$$\pi$$" during tests, which previously caused excessive rendering requests.
-                // ! This check ensures LaTeX is not transformed if we are in an editing context.
+                // ! This check ensures that the string "$$\pi$$" is not transformed by the service.
 
-                if (!$editing) {
+                if ($latex === '$$\pi$$') {
+                    $text = str_replace($latex, '<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>&pi;</mi></math>', $text);
+                } else {
                     $response = $textservice->getMathML(null, $latex);
 
                     $decodedresponse = json_decode($response, true);

--- a/subfilters/php.php
+++ b/subfilters/php.php
@@ -93,9 +93,9 @@ class filter_wiris_php extends \core_filters\text_filter {
             foreach ($matches[0] as $latex) {
                 $editing = optional_param('action', '', PARAM_ALPHA) === 'edit' || optional_param('update', 0, PARAM_INT) > 0;
 
-                //! Avoid transforming LaTeX in editing context to prevent unnecessary rendering requests.
-                //! Editors may inject the string "$$\pi$$" during tests, which previously caused excessive rendering requests.
-                //! This check ensures LaTeX is not transformed if we are in an editing context.
+                // ! Avoid transforming LaTeX in editing context to prevent unnecessary rendering requests.
+                // ! Editors may inject the string "$$\pi$$" during tests, which previously caused excessive rendering requests.
+                // ! This check ensures LaTeX is not transformed if we are in an editing context.
 
                 if (!$editing) {
                     $response = $textservice->getMathML(null, $latex);

--- a/subfilters/php.php
+++ b/subfilters/php.php
@@ -92,7 +92,7 @@ class filter_wiris_php extends \core_filters\text_filter {
         if (!$this->mathjax_have_preference() && $wirispluginwrapper->wiris_editor_parse_latex()) {
             foreach ($matches[0] as $latex) {
 
-                // ! For some reason, strayed `pi` LaTeX expressions are included in some Moodle pages by default. 
+                // ! For some reason, strayed `pi` LaTeX expressions are included in some Moodle pages by default.
                 // ! This implies our services having to convert them into MathML and then rendering them as an image without the user even interacting with MathType to begin with.
                 // ! To avoid this extra requests, which may impact our services, we just hardcoded it´s conversion to MathML.
                 // ! NOTE: requests to latex2mahtml service aren't cached, worsening this situation.

--- a/subfilters/php.php
+++ b/subfilters/php.php
@@ -92,10 +92,10 @@ class filter_wiris_php extends \core_filters\text_filter {
         if (!$this->mathjax_have_preference() && $wirispluginwrapper->wiris_editor_parse_latex()) {
             foreach ($matches[0] as $latex) {
 
-                // ! For some reason, strayed `pi` LaTeX expressions are included in some Moodle pages by default.
-                // ! This implies our services having to convert them into MathML and then rendering them as an image without the user even interacting with MathType to begin with.
-                // ! To avoid this extra requests, which may impact our services, we just hardcoded it´s conversion to MathML.
-                // ! NOTE: requests to latex2mahtml service aren't cached, worsening this situation.
+                // For some reason, strayed `pi` LaTeX expressions are included in some Moodle pages by default.
+                // This implies our services having to convert them into MathML and then rendering them as an image without the user even interacting with MathType to begin with.
+                // To avoid this extra requests, which may impact our services, we just hardcoded it´s conversion to MathML.
+                // NOTE: requests to latex2mahtml service aren't cached, worsening this situation.
 
                 if ($latex === '$$\pi$$') {
                     $text = str_replace($latex, '<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>&pi;</mi></math>', $text);


### PR DESCRIPTION
Avoid transforming LaTeX in editing context to prevent unnecessary rendering requests.
Editors may inject the string "$$\pi$$" during tests, which previously caused excessive rendering requests.
This check ensures that the string "$$\pi$$" is not transformed by the service.
