### PR TITLE
fix: Viewer language

### DIFF
--- a/subfilters/client.php
+++ b/subfilters/client.php
@@ -53,9 +53,13 @@ class filter_wiris_client extends \core_filters\text_filter {
      */
     public function filter($text, array $options = []) {
         global $PAGE;
+
+        // Get Moodle current language.
+        $lang = current_language();
+        
         // Add the Javascript Thir-party library to the page.
         $PAGE->requires->js(
-            new moodle_url('/filter/wiris/render/WIRISplugins.js?viewer=image&safeXml=true&async=true&element=%23page&ignored_containers=[data-fieldtype="editor"]')
+            new moodle_url('/filter/wiris/render/WIRISplugins.js?viewer=image&lang=' . $lang . '&safeXml=true&async=true&element=%23page&ignored_containers=[data-fieldtype="editor"]')
         );
 
         // Uses the option 'safeXml' to True to render directly from Safe MathML as stored on the database.


### PR DESCRIPTION
## Description

Using render client mode on Moodle changes the whole moodle language in some cases

- **Related Kanbanize Card:** [Link to KB-60641](https://wiris.kanbanize.com/ctrl_board/2/cards/60641/details/)

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes

## How should be tested? 

1. Change the Moodle to Spanish, for example.
2. Go to a Moodle course.
3. Select a quizz.
4. Go to the question bank.
5. Click preview on any question that contains the editor.
6. Click Submit and Finish until you see the page language change
