### PR TITLE
test: add correct installation of wq after deprecation of moodle > 4.5

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -241,6 +241,7 @@ jobs:
         run: |
           moodle-plugin-ci add-plugin --branch ${{ env.BRANCH_NAME }} wiris/moodle-qtype_wq
       - name: Add Wiris Quizzes plugin using the v4.14.0 tag
+      - id: add-quizzes-legacy
         if: ${{ contains(fromJson('["MOODLE_39_STABLE", "MOODLE_311_STABLE", "MOODLE_400_STABLE", "MOODLE_401_STABLE", "MOODLE_402_STABLE", "MOODLE_403_STABLE", "MOODLE_404_STABLE"]'), matrix.moodle_branch) && steps.install-plugin-quizzes.outcome != 'success' }}
         run: |
           moodle-plugin-ci add-plugin --branch v4.14.0 wiris/moodle-qtype_wq

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -247,7 +247,7 @@ jobs:
           moodle-plugin-ci add-plugin --branch v4.14.0 wiris/moodle-qtype_wq
 
       - name: Add Wiris Quizzes plugin using the main branch
-        if: ${{ steps.add-quizzes-tag.conclusion == 'skipped' && steps.install-plugin-quizzes.outcome != 'success' }}
+        if: ${{ steps.add-quizzes-legacy.conclusion == 'skipped' && steps.install-plugin-quizzes.outcome != 'success' }}
         run: |
           moodle-plugin-ci add-plugin --branch main wiris/moodle-qtype_wq
 

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -240,8 +240,13 @@ jobs:
         continue-on-error: true
         run: |
           moodle-plugin-ci add-plugin --branch ${{ env.BRANCH_NAME }} wiris/moodle-qtype_wq
+      - name: Add Wiris Quizzes plugin using the v4.14.0 tag
+        if: ${{ contains(fromJson('["MOODLE_39_STABLE", "MOODLE_311_STABLE", "MOODLE_400_STABLE", "MOODLE_401_STABLE", "MOODLE_402_STABLE", "MOODLE_403_STABLE", "MOODLE_404_STABLE"]'), matrix.moodle_branch) && steps.install-plugin-quizzes.outcome != 'success' }}
+        run: |
+          moodle-plugin-ci add-plugin --branch v4.14.0 wiris/moodle-qtype_wq
+
       - name: Add Wiris Quizzes plugin using the main branch
-        if: ${{ steps.install-plugin-quizzes.outcome != 'success' }}
+        if: ${{ !contains(fromJson('["MOODLE_39_STABLE", "MOODLE_311_STABLE", "MOODLE_400_STABLE", "MOODLE_401_STABLE", "MOODLE_402_STABLE", "MOODLE_403_STABLE", "MOODLE_404_STABLE"]'), matrix.moodle_branch) && steps.install-plugin-quizzes.outcome != 'success' }}
         run: |
           moodle-plugin-ci add-plugin --branch main wiris/moodle-qtype_wq
 

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -247,7 +247,7 @@ jobs:
           moodle-plugin-ci add-plugin --branch v4.14.0 wiris/moodle-qtype_wq
 
       - name: Add Wiris Quizzes plugin using the main branch
-        if: ${{ !contains(fromJson('["MOODLE_39_STABLE", "MOODLE_311_STABLE", "MOODLE_400_STABLE", "MOODLE_401_STABLE", "MOODLE_402_STABLE", "MOODLE_403_STABLE", "MOODLE_404_STABLE"]'), matrix.moodle_branch) && steps.install-plugin-quizzes.outcome != 'success' }}
+        if: ${{ steps.add-quizzes-tag.conclusion == 'skipped' && steps.install-plugin-quizzes.outcome != 'success' }}
         run: |
           moodle-plugin-ci add-plugin --branch main wiris/moodle-qtype_wq
 

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -241,7 +241,7 @@ jobs:
         run: |
           moodle-plugin-ci add-plugin --branch ${{ env.BRANCH_NAME }} wiris/moodle-qtype_wq
       - name: Add Wiris Quizzes plugin using the v4.14.0 tag
-      - id: add-quizzes-legacy
+        id: add-quizzes-legacy
         if: ${{ contains(fromJson('["MOODLE_39_STABLE", "MOODLE_311_STABLE", "MOODLE_400_STABLE", "MOODLE_401_STABLE", "MOODLE_402_STABLE", "MOODLE_403_STABLE", "MOODLE_404_STABLE"]'), matrix.moodle_branch) && steps.install-plugin-quizzes.outcome != 'success' }}
         run: |
           moodle-plugin-ci add-plugin --branch v4.14.0 wiris/moodle-qtype_wq


### PR DESCRIPTION
## Description
Recently wq has changed the minimum required version of moodle for the wq thus breaking new instalations off the plugin on older moodles.

- **Related Kanbanize Card:** [Link to KB-66484](https://wiris.kanbanize.com/ctrl_board/2/cards/66484/details/)

